### PR TITLE
Rename Validate method to Check

### DIFF
--- a/CQRSlight.Db/Abstract/IDbChecker.cs
+++ b/CQRSlight.Db/Abstract/IDbChecker.cs
@@ -6,9 +6,9 @@ namespace CQRSlight.Db.Abstract
 {
     public interface IDbChecker<in TEntity>
     {
-        [Obsolete("You must use the Validate method instead of this. This method will be removed in 1.0.2")]
+        [Obsolete("You must use the Check method instead of this. This method will be removed in 1.0.2")]
         IOutcome IsValid(IDbExecutor dbExecutor, TEntity entity);
 
-        IOutcome Validate(IDbExecutor dbExecutor, TEntity entity);
+        IOutcome Check(IDbExecutor dbExecutor, TEntity entity);
     }
 }

--- a/CQRSlight/Abstract/IChecker.cs
+++ b/CQRSlight/Abstract/IChecker.cs
@@ -5,9 +5,9 @@ namespace CQRSlight.Abstract
 {
     public interface IChecker<in TEntity>
     {
-        [Obsolete("You must use the Validate method instead of this. This method will be removed in 1.0.2")]
+        [Obsolete("You must use the Check method instead of this. This method will be removed in 1.0.2")]
         IOutcome IsValid(TEntity entity);
 
-        IOutcome Validate(TEntity entity);
+        IOutcome Check(TEntity entity);
     }
 }

--- a/README.md
+++ b/README.md
@@ -93,7 +93,7 @@ public class CreateUserCommand : ICommand<CreateUserCommandContext>
 ```csharp
 public class CreatingUserEmailChecker : IChecker<User>
 {
-    public IOutcome Validate(User creatingUser)
+    public IOutcome Check(User creatingUser)
     {
         if(string.isNullOrWhiteSpace(creatingUser.Email))
             return Outcomes.Failure().WithMessage($"Email is required.")
@@ -203,7 +203,7 @@ public class AddNewAccountToUserCommand : DbCommand<Account>
     public override IOutcome Execute(Account userAccount)
     {
         var accountChecker = new UserAccountChecker(DbExecutor);
-        var checkAccountResult = accountChecker.Validate(userAccount);
+        var checkAccountResult = accountChecker.Check(userAccount);
         var accountIsValid = checkAccountResult.Success();
         if(!accountIsValid)
             return checkAccountResult;


### PR DESCRIPTION
Because it belongs to the `Checker` class and not the `Validator`